### PR TITLE
fixes issue(s) with icons not resolving in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,29 @@ module.exports = (api, options) => {
           }
         ])
       }
+      if (cfg.plugins.has('copy')) {
+        cfg.plugin('copy').tap((args) => {
+          args[0].push({
+            from: 'src-tauri/icons/',
+            to: '../../icons',
+            force: true
+          });
+          return args;
+        })
+      } else {
+        cfg.plugin('copy').use(CopyPlugin, [
+          {
+            patterns: [
+              {
+                from: 'src-tauri/icons/',
+                to: '../../icons',
+                force: true
+              }
+            ]
+          }
+
+        ]);
+      }
 
       // Apply custom config from user
       if (pluginOptions.chainWebpack) {
@@ -72,7 +95,7 @@ module.exports = (api, options) => {
       if (!args.skipBundle) {
         try {
           await api.service.run('build', {
-            dest: 'dist_tauri/webpack_dist'
+            dest: 'dist_tauri/target/webpack_dist'
           })
         } catch (e) {
           error(
@@ -82,12 +105,12 @@ module.exports = (api, options) => {
         }
       }
 
-      process.env.CARGO_TARGET_DIR = api.resolve('dist_tauri')
+      process.env.CARGO_TARGET_DIR = api.resolve('dist_tauri/target')
       build({
         build: {
           // Has to be a non-empty string, value doesn't matter
           devPath: ' ',
-          distDir: '../dist_tauri/webpack_dist'
+          distDir: '../dist_tauri/target/webpack_dist'
         },
         ctx: { debug: args.debug },
         verbose: args.verbose


### PR DESCRIPTION
resolves:
#https://github.com/tauri-apps/tauri/issues/1003
#https://github.com/tauri-apps/tauri/issues/992

This *shouldn't* break anything, this should be fully compatible with anything NOT using dist\_tauri, but do note it changes the target location _in_ dist\_tauri by adding a directory in dist\_tauri to hit the depth that's expected by wix.rs (two directories popped off the end).

Note that I have successfully tested with [https://github.com/orogene/orogene](building Orogene), but have not dug in deep enough with doing a test reconfiguration to confirm that the second branch (copy not already present) works correctly if a CopyPlugin hasn't already been set in the webpack config.