### PR TITLE
Fixes issue following change back to using src-tauri as target dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ module.exports = (api, options) => {
         }
       }
 
+      process.env.CARGO_TARGET_DIR = api.resolve('src-tauri/target');
       build({
         build: {
           // Has to be a non-empty string, value doesn't matter


### PR DESCRIPTION
following 12.0.1, building was failing at tauri-bundler stage in both Windows and Linux:
![image](https://user-images.githubusercontent.com/2348960/91914953-8d59f380-ec76-11ea-9e3c-dc3c42118837.png)
![image](https://user-images.githubusercontent.com/2348960/91914990-a19df080-ec76-11ea-84eb-736dca8dec78.png)

setting the CARGO_TARGET_DIR explicitly to the src-tauri/target dir fixes this:
![image](https://user-images.githubusercontent.com/2348960/91915110-f04b8a80-ec76-11ea-9a27-8a8e596e8199.png)
![image](https://user-images.githubusercontent.com/2348960/91915326-7a93ee80-ec77-11ea-90fa-45db6863e814.png)
