### PR TITLE
fix args.b undefined while use --target

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,11 +92,11 @@ module.exports = (api, options) => {
       }
       if (args.t || args.target) {
         cliArgs.push('--target')
-        cliArgs.push(args.t)
+        cliArgs.push(args.t ? args.t : args.target)
       }
       if (args.b || args.bundle) {
         cliArgs.push('--bundle')
-        cliArgs.push(args.b)
+        cliArgs.push(args.b ? args.b : args.bundle)
       }
       cli.run(cliArgs)
     }


### PR DESCRIPTION
if run command `npx vue-cli-service tauri:build --target universal-apple-darwin`.It will return an error `Error: Failed to convert napi `string` into rust type `String``.the args.b is undefined.